### PR TITLE
Update to logging details

### DIFF
--- a/sam-app/lambda_functions/salesforce.py
+++ b/sam-app/lambda_functions/salesforce.py
@@ -195,30 +195,34 @@ class Salesforce:
 
 class Request:
   def post(self, url, headers, data=None, params=None, hideData=False):
-    logger.info('POST Requests:\nurl=%s' % url)
+    logger.info('Request post')
+    logger.debug('POST Requests:\nurl=%s' % url)
     if not hideData:
-      logger.info("data=%s\nparams=%s" % (data, params))
+      logger.debug("data=%s\nparams=%s" % (data, params))
     r = requests.post(url=url, data=json.dumps(data), params=params, headers=headers)
     if not hideData:
-      logger.info("Response: %s" % r.text)
+      logger.debug("Response: %s" % r.text)
     return __check_resp__(r)
 
   def delete(self, url, headers):
-    logger.info("DELETE Requests:\nurl=%s" % url)
+    logger.info('Request delete')
+    logger.debug("DELETE Requests:\nurl=%s" % url)
     r = requests.delete(url=url, headers=headers)
-    logger.info("Response: %s" % r.text)
+    logger.debug("Response: %s" % r.text)
     return __check_resp__(r)
 
   def patch(self, url, data, headers):
-    logger.info("PATCH Requests:\nurl=%s\ndata=%s" % (url, data))
+    logger.info('Request patch')
+    logger.debug("PATCH Requests:\nurl=%s\ndata=%s" % (url, data))
     r = requests.patch(url=url, data=json.dumps(data), headers=headers)
-    logger.info("Response: %s" % r.text)
+    logger.debug("Response: %s" % r.text)
     return __check_resp__(r)
 
   def get(self, url, params, headers):
-    logger.info("GET Requests:\nurl=%s\nparams=%s" % (url, params))
+    logger.info('Request get')
+    logger.debug("GET Requests:\nurl=%s\nparams=%s" % (url, params))
     r = requests.get(url=url, params=params, headers=headers)
-    logger.info("Response: %s" % r.text)
+    logger.debug("Response: %s" % r.text)
     return __check_resp__(r)
 
 def __check_resp__(resp):

--- a/sam-app/lambda_functions/sf_util.py
+++ b/sam-app/lambda_functions/sf_util.py
@@ -111,7 +111,7 @@ def getS3FileMetadata(Bucket, ContactId):
     oMetadata = {}
     s3 = boto3.client('s3')
     response = s3.head_object(Bucket=Bucket, Key='locks/' + ContactId + '.lock')
-    logger.info('GetS3FileMetadata Response: %s ' % response)
+    logger.debug('GetS3FileMetadata Response: %s ' % response)
     if 'Metadata' in response:
         oMetadata = response['Metadata']
     return oMetadata
@@ -142,7 +142,7 @@ def invokeSfAPI(sfRequest):
     if(sfLambdaResponse['StatusCode']==200):
         responsePayload = sfLambdaResponse['Payload'].read()
         responsePayload = responsePayload.decode('utf8')
-        logger.info('SF API Lambda Response %s' %responsePayload)
+        logger.debug('SF API Lambda Response %s' %responsePayload)
         responsePayload = json.loads(responsePayload)
         if 'errorMessage' in responsePayload:
             raise ValueError('Error SFDC Lambda: ' + json.dumps(responsePayload))


### PR DESCRIPTION
Changed `logger.info` to `logger.debug` where the logs include data from and to SFDC
REASON: this data could contain Personal Identifiable Information returned in queries from SFDC
Added logger.info to Request class to show which function was called.

*Issue #, if available:* #5 

*Description of changes:*

We found that Logging Level `INFO` is logging too much information, such as queries responses from SFDC requests, which ideally should be in DEBUG logging levels. The main concern here is that the data being logged contains personally identifiable information. Moving the request and response data to a `DEBUG` log level will allow users to exclude PII from their logs while using `INFO` and still be able to see what the lambdas are doing.  Should help the users that need to be GDPR compliant.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
