### PR TITLE
remove StackName from CW event rule target id

### DIFF
--- a/sam-app/lambda_functions/template.yaml
+++ b/sam-app/lambda_functions/template.yaml
@@ -1266,7 +1266,7 @@ Resources:
       Targets:
         -
           Arn: !Ref sfRealTimeQueueMetricsLoopJobStateMachine
-          Id: !Sub '${AWS::StackName}-sfRealTimeQueue'
+          Id: sfRealTimeQueue
           RoleArn: !GetAtt sfRealTimeQueueMetricsCronExecutionRole.Arn
 
   sfRealTimeQueueMetricsCronExecutionRole:


### PR DESCRIPTION
remove AWS::StackName pseudo parameter from "sfRealTimeQueueMetricsCron.targets.1"

*Description of changes:*
when deploying this package as a nested stack it failed due to 64 characters limit
```
1 validation error detected: Value 'XXX-TTYSRYK8OZ3T-sfRealTimeQueue' at 'targets.1.member.id' failed to satisfy constraint: Member must have length less than or equal to 64 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
