### PR TITLE
Add AWS region name into ac_record_id for Historical Queue export for multi-instances setup:

### DIFF
--- a/sam-app/lambda_functions/sfIntervalQueue.py
+++ b/sam-app/lambda_functions/sfIntervalQueue.py
@@ -49,11 +49,13 @@ def lambda_handler(event, context):
   logger.info("key: %s" % key)
   data = s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode()
 
+  runtime_region = os.environ['AWS_REGION']
+
   sf = Salesforce()
 
   for record in csv.DictReader(data.split("\n")):
     queue_record = prepare_queue_record(record, event_record['eventTime'])
-    ac_record_id = "%s%s" % (queue_record[pnamespace + 'AC_Object_Name__c'], queue_record[pnamespace + 'StartInterval__c'])
+    ac_record_id = "%s%s%s" % (queue_record[pnamespace + 'AC_Object_Name__c'], queue_record[pnamespace + 'StartInterval__c'], runtime_region)  # Add AWS region into recordID for multi-instance setup
     #logger.info("sfIntervalAgent ac_record_id: %s" % ac_record_id)
     #logger.info("sfIntervalAgent record: %s" % queue_record)
     # logger.info("sfIntervalAgent record: %s" % agent_record)


### PR DESCRIPTION
Add AWS region name into ac_record_id for Historical Queue export for multi-instances setup:

This is needed when having multiple Amazon connect instance export data to the same Salesforce environment and Queue names in the Amazon Connect instances are identical

*Issue #, if available:*

*Description of changes:

1)	The integration is working as-is if: 
     a.	Queue names are different on all 3 instances
     b.	Queue names are similar but no calls happen on the same queue in the same 30 minute interval
2)	In our case, when testing to place one call on the 3 instances targeting the same Queue here is what happens: 
     a.	First call to be processed is well created into Salesforce
     b.	Second and Third are overwriting this first entry
     c.	The result is that only one call is kept into Salesforce (the last one writing)
3)	In order to avoid this I have modified the lambda exporting the Queue data (sfIntervalQueue): 
     a.	Unicity is done on a field called ac_record_id
     b.	This field is passed in the URL of the API call (https://XXXX.my.salesforce.com/services  /data/v51.0/sobjects/amazonconnect__AC_HistoricalQueueMetrics__c/amazonconnect__AC_Record_Id__c/HOS-Sales and Event Management-ENG2021-02-16T16:00:00.000Z)
c.	It is built using [Queue Name][StartInterval] (this is why the data gets overwritten when the queue name and interval are identical)
d.	I have added the region to this parameter (https://XXXX.my.salesforce.com/services/data/v51.0/sobjects/amazonconnect__AC_HistoricalQueueMetrics__c/amazonconnect__AC_Record_Id__c/HOS-Sales and Event Management-ENG2021-02-16T16:00:00.000Zus-east-1)
e.	With this I can see 2 records for 2 calls from different instances into Salesforce:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
