### PR TITLE
Contact Lens Fix

### DIFF
--- a/sam-app/lambda_functions/sfContactLensUtil.py
+++ b/sam-app/lambda_functions/sfContactLensUtil.py
@@ -109,7 +109,7 @@ def processContactLensConversationCharacteristics(contactLensObj, connectBucket,
     contactId = contactLensObj['CustomerMetadata']['ContactId']
     if ('postcallRedactedRecordingImportEnabled' in contactAttributes and contactAttributes['postcallRedactedRecordingImportEnabled'] == 'true'):
         logger.info('Redacted recording import is enabled')
-        redactedRecordingLocation = getRedactedRecordingLocation(ContactId, connectBucket)
+        redactedRecordingLocation = getRedactedRecordingLocation(contactId, connectBucket)
         resultSet['recordingPath'] = redactedRecordingLocation
     else:
         resultSet['recordingPath'] = None

--- a/sam-app/lambda_functions/sfGenerateAudioRecordingStreamingURL.py
+++ b/sam-app/lambda_functions/sfGenerateAudioRecordingStreamingURL.py
@@ -57,7 +57,11 @@ def lambda_handler(event, context):
     logger.info("Cloudfront credentials retrieved")
 
     # construct url to audio recording
-    recordingPath = event['recordingPath'].split("/connect/", 1)[1] # need to remove bucket name, connect dir from path
+    if '/connect/' in event['recordingPath']:
+        recordingPath = event['recordingPath'].split("/connect/", 1)[1] # need to remove bucket name, connect dir from path
+    elif '/Analysis/' in event['recordingPath']:
+        recordingPath = event['recordingPath'].split("/Analysis/", 1)[1] # For the contact lens recordings
+
     cloudfront_domain = get_arg(os.environ, 'CLOUDFRONT_DISTRIBUTION_DOMAIN_NAME')
     url = 'https://' + cloudfront_domain + '/' + recordingPath
     logger.info('Unsigned audio recording url: %s' % url)

--- a/sam-app/lambda_functions/template.yaml
+++ b/sam-app/lambda_functions/template.yaml
@@ -961,9 +961,18 @@ Resources:
             TargetOriginId: AudioRecordingStreamingCloudFrontOrigin
             TrustedSigners: [self]
             ViewerProtocolPolicy: redirect-to-https
+          CacheBehaviors:
+          - AllowedMethods: [GET, HEAD, OPTIONS]
+            Compress: true
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+            OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf # Managed-CORS-S3Origin
+            PathPattern: /Voice/*
+            TargetOriginId: AudioRecordingStreamingCloudFrontOrigin-analysis
+            TrustedSigners: [self]
+            ViewerProtocolPolicy: redirect-to-https
           Enabled: true
           IPV6Enabled: true
-          Origins: 
+          Origins:
           - DomainName: !Join ['.', [!Ref ConnectRecordingS3BucketName, 's3', !Ref 'AWS::Region', 'amazonaws.com']]
             Id: AudioRecordingStreamingCloudFrontOrigin
             CustomOriginConfig:
@@ -972,8 +981,18 @@ Resources:
               - TLSv1.2
             OriginCustomHeaders:
             - HeaderName: Access-Control-Allow-Origin
-              HeaderValue: "https://www.google.com"
-            OriginPath: /connect
+              HeaderValue: !Ref SalesforceHost
+            OriginPath: /connect 
+          - DomainName: !Join ['.', [!Ref ConnectRecordingS3BucketName, 's3', !Ref 'AWS::Region', 'amazonaws.com']]
+            Id: AudioRecordingStreamingCloudFrontOrigin-analysis
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols: 
+              - TLSv1.2
+            OriginCustomHeaders:
+            - HeaderName: Access-Control-Allow-Origin
+              HeaderValue: !Ref SalesforceHost
+            OriginPath: /Analysis
 
   sfGetTranscribeJobStatus:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Issue : The current Lambda Package seems to have an issue with the playback of Contact Lens recordings in Salesforce, mainly because the redacted recordings are in '/Analysis' path and the default audio recordings are in '/connect'

Changes : 
- updated the sfGenerateAudioRecordingStreamingURL lambda to accommodate the contact lens paths
- fixed a small typo in the sfContactLensUtil lambda
- updated the Cloudfront distribution in the SAM template to have another origin for /Analysis

Apart from the code changes, some other actions that can be updated in the documentation : 
- For S3 permissions, include the visual force page and the lightning page : 

1. Visual force page base URL for AC_RecordingViewer
2. https://{salesforce instance}.lightning.force.com ( Lightning page for the Contact Lens Viewer )

- The sfSig4RequestToS3 Lambda has to be deployed to the Lambda Edge for 2 origins paths,  '\*' and '/Voice/*'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
