### PR TITLE
-adding Agent statuses to sfIntervalAgent

### DIFF
--- a/sam-app/lambda_functions/sfIntervalAgent.py
+++ b/sam-app/lambda_functions/sfIntervalAgent.py
@@ -79,6 +79,12 @@ def prepare_agent_record(record_raw, current_date):
   return record
 
 def label_parser(key):
+
+  agent_status = ["Paperwork time","Training/Coaching time","Outbound Campaign time","Comfort Break time","In a meeting time","Paperwork time","On Lunch time"]
+  
+  if key in agent_status: 
+    return "%s__c" % key.replace(" ", "_").replace("/","_")
+    
   if key.lower() == 'average agent interaction and customer hold time':#To Long
     return pnamespace + 'Avg_agent_interaction_and_cust_hold_time__c'
 


### PR DESCRIPTION


Including changes that allow agent statuses to be used for reporting on Salesforce. 

Agent statuses have been directly added to the script. Final solution should store agent statuses on environment variables for easy updates without changing the code. However, due to permissions, the agent status have to be hard coded in to get them functioning. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
