### PR TITLE
Mapped Disconnect Reason to Salesforce field

### DIFF
--- a/sam-app/lambda_functions/sfContactTraceRecord.py
+++ b/sam-app/lambda_functions/sfContactTraceRecord.py
@@ -102,6 +102,7 @@ def create_ctr_record(ctr):
     sf_request[objectnamespace + 'NextContactId__c'] = ctr['NextContactId']
     sf_request[objectnamespace + 'PreviousContactId__c'] = ctr['PreviousContactId']
     sf_request[objectnamespace + 'DisconnectTimestamp__c'] = ctr['DisconnectTimestamp']
+    sf_request[objectnamespace + 'DisconnectReason__c'] = ctr['DisconnectReason']
 
     # Queue
     if ctr['Queue']:


### PR DESCRIPTION
The current solution is not mapping Disconnect Reason to Salesforce.

*Issue #, if available:* NA

*Description of changes:*
The Disconnect Reason for the call is not getting mapped into Salesforce.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
