### PR TITLE
feat(sam-app): add parameter to optionally override the sfInvokeApi Lambda Timeout

### DIFF
--- a/sam-app/lambda_functions/template.yaml
+++ b/sam-app/lambda_functions/template.yaml
@@ -160,6 +160,11 @@ Parameters:
     Type: CommaDelimitedList
     Description: The list of Subnets for the Virtual Private Cloud (VPC). Not required if PrivateVpcEnabled is set to false.
     Default: ''
+  SfInvokeApiTimeout:
+    Type: Number
+    Default: 0
+    Description: Override the Lambda timeout (in seconds). 0 means use global default.
+
 
 
 Conditions:
@@ -177,6 +182,7 @@ Conditions:
   SalesforceCredentialsKMSKeyARNHasValue: !Not [!Equals [!Ref SalesforceCredentialsKMSKeyARN, '']]
   CTRKinesisARNHasValue: !Not [!Equals [!Ref CTRKinesisARN, '']]
   AmazonConnectInstanceIdHasValue: !Not [!Equals [!Ref AmazonConnectInstanceId, '']]
+  SfInvokeApiTimeoutOverride: !Not [!Equals [!Ref SfInvokeApiTimeout, 0]]
 
   CTREventSourceMappingCondition:
     !And
@@ -1025,6 +1031,11 @@ Resources:
           Fn::GetAtt: sfLambdaBasicExec.Arn
         Layers:
           - Ref: sfLambdaLayer
+        Timeout:
+          !If
+            - SfInvokeApiTimeoutOverride
+            - !Ref SfInvokeApiTimeout
+            - !Ref AWS::NoValue # Default to Global.Function.Timeout
         Environment:
             Variables:
                 SF_HOST:


### PR DESCRIPTION
## *Issue #, if available:*

None

## *Description of changes:*

### Problem statement

When deploying this SAM stack in order to connect Amazon Connect with Salesforce, we often found that the `sfInvokeAPI` Lambda was resulting in timeouts - not by much, yet frequently enough for it to be an issue.

Given its timeout defaults to the one define as a Global for all the Lambda functions (that wouldn't have it overridden) in the stack, it means we were unable to specifically increase this one.

As of now, we have the following hack as a pre-hook in our tool (Spacelift) that handles this stack's deployment:

```terraform
  before_init = [
    "wget https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_amd64.tar.gz -O - | tar xz && mv yq_linux_amd64 /tmp/yq",
    "/tmp/yq e '.Resources.sfInvokeAPI.Properties.Timeout = 20' sam-app/lambda_functions/template.yaml -i",
    "echo '.Globals.Function.Timeout overridden from default 6sec to 20sec'"
  ]
```

We'd very much favor just defining a parameter through an environment variable, just like we do for the rest of the parameters.

### Proposed solution

This PR introduced a `SfInvokeApiTimeout` **optional** parameter that is used for the `sfInvokeAPI` Lambda if found - and otherwise default to the Global. That means that it doesn't change anything for existing users, and allows the ones who need to increase it to do so specifically.

Happy to discuss the proposed change or learn about another option we might have missed!

_Note: I'm also sharing this PR with our AWS TAM and SA along the way_

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
